### PR TITLE
Set the BUILDER_SELECTION env var

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -7,6 +7,7 @@
 # Enables builder api for lodestar VC and charon services.
 #BUILDER_API_ENABLED=
 #BUILDER_API_RELAY_URL=http://mev-boost:18550
+#BUILDER_SELECTION=
 
 ######### Geth Config #########
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -112,6 +112,7 @@ services:
       BEACON_NODE_ADDRESS: http://charon:3600
       NETWORK: ${NETWORK:-holesky}
       BUILDER_API_ENABLED: ${BUILDER_API_ENABLED:-true}
+      BUILDER_SELECTION: ${BUILDER_SELECTION:-builderonly}
     volumes:
       - ./lodestar/run.sh:/opt/lodestar/run.sh
       - .charon/validator_keys:/home/charon/validator_keys


### PR DESCRIPTION
As per the docs best practice https://docs.obol.tech/docs/next/int/quickstart/advanced/quickstart-builder-api#validator-clients 

It's present in lodestar/run.sh but not set anywhere I can see