### PR TITLE
Add missing space to docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -172,7 +172,7 @@ services:
   #   \_/ \__,_|_|_|\__,_|\__,_|\__\___/|_|        \___|/ |\___|\___|\__\___/|_|
   #                                                   |__/
 
- validator-ejector:
+  validator-ejector:
    image: lidofinance/validator-ejector:${VALIDATOR_EJECTOR_VERSION:-stable}
    user: ":"
    networks: [dvnode]


### PR DESCRIPTION
The current version of the main `docker-compose.yml` file has a syntax error, resulting in docker failing to parse the file ( `parsing /home/admin/lido-charon-distributed-validator-node/docker-compose.yml: yaml: line 175: did not find expected key` ).

Introduced in #4 .