### PR TITLE
Update docker-compose.yml - Fix indendation issue

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -172,7 +172,7 @@ services:
   #   \_/ \__,_|_|_|\__,_|\__,_|\__\___/|_|        \___|/ |\___|\___|\__\___/|_|
   #                                                   |__/
 
- validator-ejector:
+  validator-ejector:
    image: lidofinance/validator-ejector:${VALIDATOR_EJECTOR_VERSION:-stable}
    user: ":"
    networks: [dvnode]


### PR DESCRIPTION
The docker compose file has an indentation / parsing error and will not work in the current form. 

The fix is a simple space.