### PR TITLE
docker-compose: update charon to v0.18.0

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -41,7 +41,7 @@
 
 ######### Charon Config #########
 
-# Charon docker container image version, e.g. `latest` or `v0.17.0`.
+# Charon docker container image version, e.g. `latest` or `v0.18.0`.
 # See available tags https://hub.docker.com/r/obolnetwork/charon/tags.
 #CHARON_VERSION=
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -77,7 +77,7 @@ services:
   #  \___|_| |_|\__,_|_|  \___/|_| |_|
 
   charon:
-    image: obolnetwork/charon:${CHARON_VERSION:-v0.17.2}
+    image: obolnetwork/charon:${CHARON_VERSION:-v0.18.0}
     environment:
       - CHARON_BEACON_NODE_ENDPOINTS=${CHARON_BEACON_NODE_ENDPOINTS:-http://lighthouse:5052}
       - CHARON_LOG_LEVEL=${CHARON_LOG_LEVEL:-info}


### PR DESCRIPTION
Update .env comment to reflect that as well, and use v0.18.0 as default in docker-compose.yml.