### PR TITLE
docker-compose: fix lido-dv-exit tag

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -198,7 +198,7 @@ services:
   #
 
   lido-dv-exit:
-    image: obolnetwork/lido-dv-exit:${LIDO_DV_EXIT_VERSION:-latest}
+    image: obolnetwork/lido-dv-exit:${LIDO_DV_EXIT_VERSION:-2403635}
     user: ":"
     networks: [dvnode]
     volumes:


### PR DESCRIPTION
Use latest available git tag rather than `latest`.

This way operators will update it on restart as well without having to run `docker pull` manually.