### PR TITLE
prometheus: don't explicitly push validator-ejector metrics

### DIFF
--- a/prometheus/prometheus.yml
+++ b/prometheus/prometheus.yml
@@ -8,11 +8,8 @@ remote_write:
       credentials: $PROM_REMOTE_WRITE_TOKEN
     write_relabel_configs:
       - source_labels: [job]
-        regex: "validator-ejector"
-        action: keep # Keeps validator-ejector metrics.
-      - source_labels: [job]
         regex: "charon"
-        action: keep # Keeps charon metrics.
+        action: keep # Keeps charon metrics and drop metrics from other containers.
 
 scrape_configs:
   - job_name: "geth"


### PR DESCRIPTION
Remnant of yesterday's shenaningans with prometheus.

Revert to previous, known-working configuration.