### PR TITLE
compose-debug: explicitly push lido-dv-exit loki logs

### DIFF
--- a/compose-debug.yml
+++ b/compose-debug.yml
@@ -58,4 +58,6 @@ services:
       - LIDODVEXIT_LOKI_ADDRESSES=${CHARON_LOKI_ADDRESSES:-http://loki:3100/loki/api/v1/push}
 
 networks:
-  dvnode:
+  default:
+    name: ${CHARON_DOCKER_NETWORK:-lido-charon-distributed-validator-node_dvnode}
+    external: true

--- a/compose-debug.yml
+++ b/compose-debug.yml
@@ -52,7 +52,10 @@ services:
       - CHARON_LOKI_ADDRESSES=${CHARON_LOKI_ADDRESSES:-http://loki:3100/loki/api/v1/push}
       - CHARON_LOKI_SERVICE=charon
 
+  lido-dv-exit:
+    environment:
+      - LIDODVEXIT_LOG_LEVEL=debug
+      - LIDODVEXIT_LOKI_ADDRESSES=${CHARON_LOKI_ADDRESSES:-http://loki:3100/loki/api/v1/push}
+
 networks:
-  default:
-    name: ${CHARON_DOCKER_NETWORK:-charon-distributed-validator-node_dvnode}
-    external: true
+  dvnode:


### PR DESCRIPTION
If configured, push lido-dv-exit log to the configured `CHARON_LOKI_ADDRESSES` instances.

Re-use charon's loki variable so that both are always in sync.