### PR TITLE
docker-compose: put lido-dv-exit log in env

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -108,6 +108,9 @@
 # lido-dv-exit beacon node endpoint
 #LIDO_DV_EXIT_BEACON_NODE_URL=
 
+# Override the lido-dv-exit logging level; debug, info, warning, error.
+#LIDO_DV_EXIT_LOG_LEVEL=
+
 ######### Monitoring Config #########
 
 # Grafana docker container image version, e.g. `latest` or `9.4.3`.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -211,6 +211,8 @@ services:
       - LIDODVEXIT_CHARON_RUNTIME_DIR=/charon
       - LIDODVEXIT_EJECTOR_EXIT_PATH=/exitmessages
       - LIDODVEXIT_EXIT_EPOCH=256
+      - LIDODVEXIT_LOG_LEVEL=${LIDO_DV_EXIT_LOG_LEVEL:-info}
     restart: on-failure
+
 networks:
   dvnode:


### PR DESCRIPTION
Easier to toggle than the whole debug setup.