### PR TITLE
docker-compose: update lido-dv-exit to 3d5c86a

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -111,6 +111,11 @@
 # Override the lido-dv-exit logging level; debug, info, warning, error.
 #LIDO_DV_EXIT_LOG_LEVEL=
 
+# Sets the amount of validator to query with each call to the beacon node.
+# Decrease in case of frequent beacon node query timeout errors for lido-dv-exit.
+# Defaults to 5.
+#LIDO_DV_EXIT_VALIDATOR_QUERY_CHUNK_SIZE=
+
 ######### Monitoring Config #########
 
 # Grafana docker container image version, e.g. `latest` or `9.4.3`.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -200,7 +200,7 @@ services:
   #
 
   lido-dv-exit:
-    image: obolnetwork/lido-dv-exit:${LIDO_DV_EXIT_VERSION:-990beba}
+    image: obolnetwork/lido-dv-exit:${LIDO_DV_EXIT_VERSION:-3d5c86a}
     user: ":"
     networks: [dvnode]
     volumes:
@@ -212,6 +212,7 @@ services:
       - LIDODVEXIT_EJECTOR_EXIT_PATH=/exitmessages
       - LIDODVEXIT_EXIT_EPOCH=256
       - LIDODVEXIT_LOG_LEVEL=${LIDO_DV_EXIT_LOG_LEVEL:-info}
+      - LIDODVEXIT_VALIDATOR_QUERY_CHUNK_SIZE=${LIDO_DV_EXIT_VALIDATOR_QUERY_CHUNK_SIZE:-5}
     restart: on-failure
 
 networks:


### PR DESCRIPTION
Also set the validator endpoint querying chunking to 5.

Useful in case of networks with lots of validators, or for clusters with many validators in it.