### PR TITLE
docker-compose: use lido-specific charon

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -77,7 +77,7 @@ services:
   #  \___|_| |_|\__,_|_|  \___/|_| |_|
 
   charon:
-    image: obolnetwork/charon:${CHARON_VERSION:-v0.18.0}
+    image: obolnetwork/charon:${CHARON_VERSION:-v0.18.0-lido2}
     environment:
       - CHARON_BEACON_NODE_ENDPOINTS=${CHARON_BEACON_NODE_ENDPOINTS:-http://lighthouse:5052}
       - CHARON_LOG_LEVEL=${CHARON_LOG_LEVEL:-debug}
@@ -88,7 +88,7 @@ services:
       - CHARON_VALIDATOR_API_ADDRESS=0.0.0.0:3600
       - CHARON_MONITORING_ADDRESS=0.0.0.0:3620
       - CHARON_BUILDER_API=${BUILDER_API_ENABLED:-true}
-      - CHARON_FEATURE_SET_ENABLE=qbft_timers_ab_test
+      - CHARON_FEATURE_SET_ENABLE=eager_double_linear,consensus_participate
       - CHARON_LOKI_ADDRESSES=${CHARON_LOKI_ADDRESSES:-http://loki:3100/loki/api/v1/push}
       - CHARON_LOKI_SERVICE=charon
     ports:


### PR DESCRIPTION
This charon version uses enables two featureset changes to allow for better consensus execution, as well as adding a Lodestar-related interaction workaround.