### PR TITLE
docker-compose: update to lido-dv-exit 20d28fd

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -213,7 +213,7 @@ services:
   #
 
   lido-dv-exit:
-    image: obolnetwork/lido-dv-exit:${LIDO_DV_EXIT_VERSION:-3d5c86a}
+    image: obolnetwork/lido-dv-exit:${LIDO_DV_EXIT_VERSION:-20d28fd}
     user: ":"
     networks: [dvnode]
     volumes:


### PR DESCRIPTION
Fixes an issue with clusters for which we have only threshold partial sigs instead of the full set.