### PR TITLE
update clients for dencun on holesky

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -11,7 +11,7 @@
 
 ######### Geth Config #########
 
-# Geth docker container image version, e.g. `latest` or `v1.12.2`.
+# Geth docker container image version, e.g. `latest` or `v1.13.11`.
 # See available tags https://hub.docker.com/r/ethereum/client-go/tags
 #GETH_VERSION=
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ services:
   #  |___/
 
   geth:
-    image: ethereum/client-go:${GETH_VERSION:-v1.13.4}
+    image: ethereum/client-go:${GETH_VERSION:-v1.13.11}
     ports:
       - ${GETH_PORT_P2P:-30303}:30303/tcp # P2P TCP
       - ${GETH_PORT_P2P:-30303}:30303/udp # P2P UDP
@@ -46,7 +46,7 @@ services:
   #      |___/
 
   lighthouse:
-    image: sigp/lighthouse:${LIGHTHOUSE_VERSION:-v4.5.0}
+    image: sigp/lighthouse:${LIGHTHOUSE_VERSION:-v4.6.0}
     ports:
       - ${LIGHTHOUSE_PORT_P2P:-9000}:9000/tcp   # P2P TCP
       - ${LIGHTHOUSE_PORT_P2P:-9000}:9000/udp   # P2P UDP
@@ -78,7 +78,7 @@ services:
   #  \___|_| |_|\__,_|_|  \___/|_| |_|
 
   charon:
-    image: obolnetwork/charon:${CHARON_VERSION:-v0.18.0-lido2}
+    image: obolnetwork/charon:${CHARON_VERSION:-v0.19.0}
     environment:
       - CHARON_BEACON_NODE_ENDPOINTS=${CHARON_BEACON_NODE_ENDPOINTS:-http://lighthouse:5052}
       - CHARON_LOG_LEVEL=${CHARON_LOG_LEVEL:-debug}
@@ -108,7 +108,7 @@ services:
   # |_|\___/ \__,_|\___||___/\__\__,_|_|
 
   lodestar:
-    image: chainsafe/lodestar:${LODESTAR_VERSION:-v1.11.3}
+    image: chainsafe/lodestar:${LODESTAR_VERSION:-v1.15.0}
     depends_on: [charon]
     entrypoint: /opt/lodestar/run.sh
     networks: [dvnode]


### PR DESCRIPTION
Update clients to support upcoming dencun fork on sepolia and holesky testnets.

https://blog.ethereum.org/2024/01/24/sepolia-holesky-dencun

ticket: https://github.com/ObolNetwork/charon-distributed-validator-node/issues/249