### PR TITLE
*: add missing env var for mainnet

### DIFF
--- a/.env.sample.mainnet
+++ b/.env.sample.mainnet
@@ -133,3 +133,6 @@ VE_LOCATOR_ADDRESS=0xC1d0b3DE6792Bf6b4b37EccdcC24e45978Cfd2Eb
 
 # validator-ejector staking module ID
 VE_STAKING_MODULE_ID=1
+
+# Lido operator ID
+#VE_OPERATOR_ID=

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -76,7 +76,7 @@ services:
   #  \___|_| |_|\__,_|_|  \___/|_| |_|
 
   charon:
-    image: obolnetwork/charon:${CHARON_VERSION:-v0.19.0}
+    image: obolnetwork/charon:${CHARON_VERSION:-v0.19.1}
     environment:
       - CHARON_BEACON_NODE_ENDPOINTS=${CHARON_BEACON_NODE_ENDPOINTS:-http://lighthouse:5052}
       - CHARON_LOG_LEVEL=${CHARON_LOG_LEVEL:-debug}


### PR DESCRIPTION
`VE_OPERATOR_ID` template env var was missing from `.env.sample.mainnet`. Add it so that the installation guide is simpler to follow.

Also bump charon to v0.19.1.