### PR TITLE
docker-compose: update for dencun

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,7 @@ services:
   # | | | |  __/ |_| | | |  __/ |  | | | | | | | | | | (_| |
   # |_| |_|\___|\__|_| |_|\___|_|  |_| |_| |_|_|_| |_|\__,_|
   nethermind:
-    image: nethermind/nethermind:${NETHERMIND_VERSION:-1.25.3}
+    image: nethermind/nethermind:${NETHERMIND_VERSION:-1.25.4}
     restart: unless-stopped
     ports:
       - ${NETHERMIND_PORT_P2P:-30303}:30303/tcp # P2P TCP
@@ -44,7 +44,7 @@ services:
   #      |___/
 
   lighthouse:
-    image: sigp/lighthouse:${LIGHTHOUSE_VERSION:-v4.6.0}
+    image: sigp/lighthouse:${LIGHTHOUSE_VERSION:-v5.0.0}
     ports:
       - ${LIGHTHOUSE_PORT_P2P:-9000}:9000/tcp # P2P TCP
       - ${LIGHTHOUSE_PORT_P2P:-9000}:9000/udp # P2P UDP
@@ -106,7 +106,7 @@ services:
   # |_|\___/ \__,_|\___||___/\__\__,_|_|
 
   lodestar:
-    image: chainsafe/lodestar:${LODESTAR_VERSION:-v1.15.0}
+    image: chainsafe/lodestar:${LODESTAR_VERSION:-v1.16.0}
     depends_on: [charon]
     entrypoint: /opt/lodestar/run.sh
     networks: [dvnode]
@@ -127,7 +127,7 @@ services:
   #  | | | | | |  __/\ V /_____| |_) | (_) | (_) \__ \ |_
   #  |_| |_| |_|\___| \_/      |_.__/ \___/ \___/|___/\__|
   mev-boost:
-    image: flashbots/mev-boost:${MEVBOOST_VERSION:-1.6}
+    image: flashbots/mev-boost:${MEVBOOST_VERSION:-1.7}
     command: |
       -${NETWORK:-mainnet}
       -loglevel=debug


### PR DESCRIPTION
Versions updated as follows:
 - nethermind: v1.25.3 -> v1.25.4
 - lighthouse: v4.6.0 -> v5.0.0 
 - lodestar: v1.15.0 -> v1.16.0
 - mevboost: 1.6 -> 1.7