### PR TITLE
*: specify mev-boost getHeader timeout

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -85,6 +85,9 @@
 # Comma separated list of MEV-Boost relays. You can choose public relays from https://enchanted-direction-844.notion.site/6d369eb33f664487800b0dedfe32171e?v=d255247c822c409f99c498aeb6a4e51d.
 #MEVBOOST_RELAYS=
 
+# Timeout in milliseconds for the getHeader request to the relay, defaults to 400.
+#MEVBOOST_TIMEOUT_GETHEADER=
+
 ##### validator-ejector Config #####
 
 # validator-ejector container image version, e.g. `stable` or `1.2.0`

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -133,6 +133,7 @@ services:
       -loglevel=debug
       -addr=0.0.0.0:18550
       -relay-check
+      -request-timeout-getheader=${MEVBOOST_TIMEOUT_GETHEADER:-400}
       -relays=${MEVBOOST_RELAYS:-"https://0xac6e77dfe25ecd6110b8e780608cce0dab71fdd5ebea22a16c0205200f2f8e2e3ad3b71d3499c54ad14d6c21b41a37ae@boost-relay.flashbots.net,https://0xa1559ace749633b997cb3fdacffb890aeebdb0f5a3b6aaa7eeeaf1a38af0a8fe88b9e4b1f61f236d2e64d95733327a62@relay.ultrasound.money,https://0xa7ab7a996c8584251c8f925da3170bdfd6ebc75d50f5ddc4050a6fdc77f2a3b5fce2cc750d0865e05d7228af97d69561@agnostic-relay.net,https://0xa15b52576bcbf1072f4a011c0f99f9fb6c66f3e1ff321f11f461d15e31b1cb359caa092c71bbded0bae5b5ea401aab7e@aestus.live"}
     networks: [dvnode]
     restart: unless-stopped


### PR DESCRIPTION
Specify a 400ms default timeout for mev-boost getHeader.

Make it configurable through env via the `MEVBOOST_TIMEOUT_GETHEADER` variable.