### PR TITLE
Docker: Exposed Ports Fix

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -15,9 +15,11 @@
 # See available tags https://hub.docker.com/r/nethermind/nethermind/tags
 #NETHERMIND_VERSION=
 
-# Nethermind host exposed ports
+# Nethermind host exposed ip and ports
 #NETHERMIND_PORT_P2P=
+#NETHERMIND_IP_HTTP=
 #NETHERMIND_PORT_HTTP=
+#NETHERMIND_IP_ENGINE=
 #NETHERMIND_PORT_ENGINE=
 
 ######### Lighthouse Config #########
@@ -132,7 +134,8 @@
 # See available tags https://github.com/grafana/grafana/releases.
 #GRAFANA_VERSION=
 
-# Grafana host exposed port
+# Grafana host exposed ip and port
+#MONITORING_IP_GRAFANA=
 #MONITORING_PORT_GRAFANA=
 
 # Prometheus docker container image version, e.g. `latest` or `v2.42.0`.

--- a/.env.sample.mainnet
+++ b/.env.sample.mainnet
@@ -13,9 +13,11 @@ NETWORK=mainnet
 # See available tags https://hub.docker.com/r/nethermind/nethermind/tags
 #NETHERMIND_VERSION=
 
-# Nethermind host exposed ports
+# Nethermind host exposed ip and ports
 #NETHERMIND_PORT_P2P=
+#NETHERMIND_IP_HTTP=
 #NETHERMIND_PORT_HTTP=
+#NETHERMIND_IP_ENGINE=
 #NETHERMIND_PORT_ENGINE=
 
 ######### Lighthouse Config #########
@@ -86,7 +88,8 @@ MEVBOOST_RELAYS=https://0xa15b52576bcbf1072f4a011c0f99f9fb6c66f3e1ff321f11f461d1
 # See available tags https://github.com/grafana/grafana/releases.
 #GRAFANA_VERSION=
 
-# Grafana host exposed port
+# Grafana host exposed ip and port
+#MONITORING_IP_GRAFANA=
 #MONITORING_PORT_GRAFANA=
 
 # Prometheus docker container image version, e.g. `latest` or `v2.42.0`.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: "3.8"
+version: '3.8'
 
 # Override any defaults specified by `${FOO:-bar}` in `.env` with `FOO=qux`.
 # ${VARIABLE:-default} evaluates to default if VARIABLE is unset or empty in the environment.
@@ -16,8 +16,8 @@ services:
     ports:
       - ${NETHERMIND_PORT_P2P:-30303}:30303/tcp # P2P TCP
       - ${NETHERMIND_PORT_P2P:-30303}:30303/udp # P2P UDP
-      - ${NETHERMIND_PORT_HTTP:-8545}:8545 # JSON-RPC
-      - ${NETHERMIND_PORT_ENGINE:-8551}:8551 # ENGINE-API
+      - ${NETHERMIND_IP_HTTP:-127.0.0.1}:${NETHERMIND_PORT_HTTP:-8545}:8545 # JSON-RPC
+      - ${NETHERMIND_IP_ENGINE:-127.0.0.1}:${NETHERMIND_PORT_ENGINE:-8551}:8551 # ENGINE-API
     command: |
       --config=${ETH2_NETWORK:-mainnet}
       --datadir=data
@@ -146,7 +146,7 @@ services:
 
   prometheus:
     image: prom/prometheus:${PROMETHEUS_VERSION:-v2.46.0}
-    user: ":"
+    user: ':'
     networks: [dvnode]
     volumes:
       - ./prometheus/prometheus.yml:/etc/prometheus/prometheus.yml
@@ -155,9 +155,9 @@ services:
 
   grafana:
     image: grafana/grafana:${GRAFANA_VERSION:-10.3.1}
-    user: ":"
+    user: ':'
     ports:
-      - ${MONITORING_PORT_GRAFANA:-3000}:3000
+      - ${MONITORING_IP_GRAFANA:-127.0.0.1}:${MONITORING_PORT_GRAFANA:-3000}:3000
     networks: [dvnode]
     volumes:
       - ./grafana/datasource.yml:/etc/grafana/provisioning/datasources/datasource.yml
@@ -169,7 +169,7 @@ services:
 
   loki:
     image: grafana/loki:${LOKI_VERSION:-2.8.2}
-    user: ":"
+    user: ':'
     networks: [dvnode]
     command: -config.file=/etc/loki/loki.yml
     volumes:
@@ -186,7 +186,7 @@ services:
 
   validator-ejector:
     image: lidofinance/validator-ejector:${VALIDATOR_EJECTOR_VERSION:-1.3.0}
-    user: ":"
+    user: ':'
     networks: [dvnode]
     volumes:
       - ./validator-ejector:/exitmessages
@@ -212,7 +212,7 @@ services:
 
   lido-dv-exit:
     image: obolnetwork/lido-dv-exit:${LIDO_DV_EXIT_VERSION:-20d28fd}
-    user: ":"
+    user: ':'
     networks: [dvnode]
     volumes:
       - ./validator-ejector:/exitmessages

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3.8'
+version: "3.8"
 
 # Override any defaults specified by `${FOO:-bar}` in `.env` with `FOO=qux`.
 # ${VARIABLE:-default} evaluates to default if VARIABLE is unset or empty in the environment.
@@ -146,7 +146,7 @@ services:
 
   prometheus:
     image: prom/prometheus:${PROMETHEUS_VERSION:-v2.46.0}
-    user: ':'
+    user: ":"
     networks: [dvnode]
     volumes:
       - ./prometheus/prometheus.yml:/etc/prometheus/prometheus.yml
@@ -155,7 +155,7 @@ services:
 
   grafana:
     image: grafana/grafana:${GRAFANA_VERSION:-10.3.1}
-    user: ':'
+    user: ":"
     ports:
       - ${MONITORING_IP_GRAFANA:-127.0.0.1}:${MONITORING_PORT_GRAFANA:-3000}:3000
     networks: [dvnode]
@@ -169,7 +169,7 @@ services:
 
   loki:
     image: grafana/loki:${LOKI_VERSION:-2.8.2}
-    user: ':'
+    user: ":"
     networks: [dvnode]
     command: -config.file=/etc/loki/loki.yml
     volumes:
@@ -186,7 +186,7 @@ services:
 
   validator-ejector:
     image: lidofinance/validator-ejector:${VALIDATOR_EJECTOR_VERSION:-1.3.0}
-    user: ':'
+    user: ":"
     networks: [dvnode]
     volumes:
       - ./validator-ejector:/exitmessages
@@ -212,7 +212,7 @@ services:
 
   lido-dv-exit:
     image: obolnetwork/lido-dv-exit:${LIDO_DV_EXIT_VERSION:-20d28fd}
-    user: ':'
+    user: ":"
     networks: [dvnode]
     volumes:
       - ./validator-ejector:/exitmessages


### PR DESCRIPTION
When declaring a port mapping without specifying an IP address Docker defaults to `0.0.0.0` and overrides existing `iptables` rules making these ports accessible to the internet. 

While it is possible to disable this behaviour by specifying `iptables: false` in `/etc/docker/daemon.json` this often results in undesirable connectivity issues as described in the docs here - [Prevent Docker from manipulating iptables](https://docs.docker.com/network/packet-filtering-firewalls/#prevent-docker-from-manipulating-iptables)

This PR restricts access to the Nethermind RPC, Engine API and Grafana dashboard to `127.0.0.1` unless the associated variables are set in `.env`. 

This does not affect connectivity between containers when referencing by container name. 