### PR TITLE
Fix: Set correct Nethermind network

### DIFF
--- a/.env.sample.mainnet
+++ b/.env.sample.mainnet
@@ -2,6 +2,7 @@
 # in docker-compose.yml. Rename this file to `.env` and then uncomment and set any variable below.
 
 # Overrides network for all the relevant services.
+ETH2_NETWORK=mainnet
 NETWORK=mainnet
 
 # Enables builder api for lodestar VC and charon services.


### PR DESCRIPTION
Commit [9cc6de0](https://github.com/ObolNetwork/lido-charon-distributed-validator-node/commit/9cc6de0dd2d07b7c81e036ee8fdaed78803badd7) sets the default network to Holesky however the value `ETH2_NETWORK` is not set in `.env.sample.mainnet` resulting in Nethermind connecting to Holesky while Lighthouse tries to connect to mainnet. 