### PR TITLE
Moving away from a holesky default

### DIFF
--- a/.env.sample.holesky
+++ b/.env.sample.holesky
@@ -2,7 +2,7 @@
 # in docker-compose.yml. Rename this file to `.env` and then uncomment and set any variable below.
 
 # Overrides network for all the relevant services.
-#NETWORK=
+NETWORK=holesky
 
 # Enables builder api for lodestar VC and charon services.
 #BUILDER_API_ENABLED=
@@ -32,7 +32,7 @@
 #LIGHTHOUSE_PORT_P2P=
 
 # Checkpoint sync url used by lighthouse to fast sync.
-#LIGHTHOUSE_CHECKPOINT_SYNC_URL=
+LIGHTHOUSE_CHECKPOINT_SYNC_URL=https://checkpoint-sync.holesky.ethpandaops.io/
 
 ######### Lodestar Config #########
 
@@ -85,7 +85,7 @@
 #MEVBOOST_VERSION=
 
 # Comma separated list of MEV-Boost relays. You can choose public relays from https://enchanted-direction-844.notion.site/6d369eb33f664487800b0dedfe32171e?v=d255247c822c409f99c498aeb6a4e51d.
-#MEVBOOST_RELAYS=
+MEVBOOST_RELAYS=https://0xafa4c6985aa049fb79dd37010438cfebeb0f2bd42b115b89dd678dab0670c1de38da0c4e9138c9290a398ecd9a0b3110@boost-relay-holesky.flashbots.net,https://0xb1d229d9c21298a87846c7022ebeef277dfc321fe674fa45312e20b5b6c400bfde9383f801848d7837ed5fc449083a12@relay-holesky.edennetwork.io,https://0xaa58208899c6105603b74396734a6263cc7d947f444f396a90f7b7d3e65d102aec7e5e5291b27e08d02c50a050825c2f@holesky.titanrelay.xyz,https://0x821f2a65afb70e7f2e820a925a9b4c80a159620582c1766b1b09729fec178b11ea22abb3a51f07b288be815a1a2ff516@bloxroute.holesky.blxrbdn.com
 
 ##### validator-ejector Config #####
 
@@ -96,9 +96,10 @@
 #DISABLE_EJECTOR_SECURITY=
 
 # Lido locator address
-#VE_LOCATOR_ADDRESS=
+VE_LOCATOR_ADDRESS=0x28FAB2059C713A7F9D8c86Db49f9bb0e96Af1ef8
 
-# ORACLE_ADDRESSES_ALLOWLIST chosen from https://mainnet.lido.fi/#/lido-dao/0x442af784a788a5bd6f42a01ebe9f287a871243fb/
+# validator-ejector oracles
+VE_ORACLE_ADDRESSES_ALLOWLIST=["0x12A1D74F8697b9f4F1eEBb0a9d0FB6a751366399","0xD892c09b556b547c80B7d8c8cB8d75bf541B2284","0xf7aE520e99ed3C41180B5E12681d31Aa7302E4e5"]
 
 # Lido staking module ID
 #VE_STAKING_MODULE_ID=
@@ -129,7 +130,7 @@
 #LIDO_DV_EXIT_VALIDATOR_QUERY_CHUNK_SIZE=
 
 # lido-dv-exit exit epoch
-#LIDODVEXIT_EXIT_EPOCH=
+LIDODVEXIT_EXIT_EPOCH=256
 
 ######### Monitoring Config #########
 

--- a/README.md
+++ b/README.md
@@ -20,17 +20,23 @@ A distributed validator node is a machine running:
 **Operators are encouraged to use this repository to build and maintain their own configurations that work for their individual use case.**
 
 
-Check the Obol [docs](https://docs.obol.tech/docs/start/quickstart_group) for detailed instructions on how to get started using this repo.
+Check the Obol [docs](https://docs.obol.tech/docs/start/quickstart_group) for detailed instructions on how to get started using example repos. 
 
-This repo is configured to run on holesky, and needs further setup for a mainnet deployment:
+To configure this repo for a particular network, follow these instructions. If you do not, your node will fail to start. 
 
-1. Copy `.env.sample.mainnet` to `.env`:
+1. Copy `.env.sample.<network-name>` to `.env`:
     ```sh
+    # mainnet
     cp .env.sample.mainnet .env
+
+    # holesky
+    cp .env.sample.holesky .env
     ```
-2. Grab your operator ID from the [lido dashboard](https://operators.lido.fi/).
+2. Grab your operator ID from the lido [mainnet dashboard](https://operators.lido.fi/) or [testnet dashboard](https://operators-holesky.testnet.fi/).
 3. Find `VE_OPERATOR_ID` in `.env` and set it to your operator ID.
 4. Save and close `.env`.
+
+You will need a `.charon/` folder from a completed DKG present to complete the setup of this repo. 
 
 # FAQs
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -50,8 +50,8 @@ services:
       - ${LIGHTHOUSE_PORT_P2P:-9000}:9000/udp # P2P UDP
     command: |
       lighthouse bn
-      --network=${NETWORK:-holesky}
-      --checkpoint-sync-url=${LIGHTHOUSE_CHECKPOINT_SYNC_URL:-https://checkpoint-sync.holesky.ethpandaops.io/}
+      --network=${NETWORK}
+      --checkpoint-sync-url=${LIGHTHOUSE_CHECKPOINT_SYNC_URL}
       --execution-endpoint=http://nethermind:8551
       --execution-jwt=/opt/jwt/jwt.hex
       --datadir=/opt/app/beacon/
@@ -112,7 +112,7 @@ services:
     networks: [dvnode]
     environment:
       BEACON_NODE_ADDRESS: http://charon:3600
-      NETWORK: ${NETWORK:-holesky}
+      NETWORK: ${NETWORK}
       BUILDER_API_ENABLED: ${BUILDER_API_ENABLED:-true}
       BUILDER_SELECTION: ${BUILDER_SELECTION:-builderonly}
     volumes:
@@ -129,11 +129,11 @@ services:
   mev-boost:
     image: flashbots/mev-boost:${MEVBOOST_VERSION:-1.7}
     command: |
-      -${NETWORK:-holesky}
+      -${NETWORK}
       -loglevel=debug
       -addr=0.0.0.0:18550
       -relay-check
-      -relays=${MEVBOOST_RELAYS:-"https://0xafa4c6985aa049fb79dd37010438cfebeb0f2bd42b115b89dd678dab0670c1de38da0c4e9138c9290a398ecd9a0b3110@boost-relay-holesky.flashbots.net,https://0xb1d229d9c21298a87846c7022ebeef277dfc321fe674fa45312e20b5b6c400bfde9383f801848d7837ed5fc449083a12@relay-holesky.edennetwork.io,https://0xaa58208899c6105603b74396734a6263cc7d947f444f396a90f7b7d3e65d102aec7e5e5291b27e08d02c50a050825c2f@holesky.titanrelay.xyz,https://0x821f2a65afb70e7f2e820a925a9b4c80a159620582c1766b1b09729fec178b11ea22abb3a51f07b288be815a1a2ff516@bloxroute.holesky.blxrbdn.com"}
+      -relays=${MEVBOOST_RELAYS}
     networks: [dvnode]
     restart: unless-stopped
 
@@ -194,10 +194,10 @@ services:
     environment:
       - EXECUTION_NODE=${VE_EXECUTION_NODE_URL:-http://nethermind:8545}
       - CONSENSUS_NODE=${VE_BEACON_NODE_URL:-http://lighthouse:5052}
-      - LOCATOR_ADDRESS=${VE_LOCATOR_ADDRESS:-0x28FAB2059C713A7F9D8c86Db49f9bb0e96Af1ef8}
+      - LOCATOR_ADDRESS=${VE_LOCATOR_ADDRESS}
       - STAKING_MODULE_ID=${VE_STAKING_MODULE_ID:-2}
       - OPERATOR_ID=${VE_OPERATOR_ID}
-      - ORACLE_ADDRESSES_ALLOWLIST=${VE_ORACLE_ADDRESSES_ALLOWLIST:-["0x12A1D74F8697b9f4F1eEBb0a9d0FB6a751366399","0xD892c09b556b547c80B7d8c8cB8d75bf541B2284","0xf7aE520e99ed3C41180B5E12681d31Aa7302E4e5"]}
+      - ORACLE_ADDRESSES_ALLOWLIST=${VE_ORACLE_ADDRESSES_ALLOWLIST}
       - MESSAGES_LOCATION=/exitmessages
       - RUN_METRICS=true
       - HTTP_PORT=8989
@@ -221,7 +221,7 @@ services:
       - LIDODVEXIT_BEACON_NODE_URL=${LIDO_DV_EXIT_BEACON_NODE_URL:-http://lighthouse:5052}
       - LIDODVEXIT_CHARON_RUNTIME_DIR=/charon
       - LIDODVEXIT_EJECTOR_EXIT_PATH=/exitmessages
-      - LIDODVEXIT_EXIT_EPOCH=${LIDODVEXIT_EXIT_EPOCH:-256}
+      - LIDODVEXIT_EXIT_EPOCH=${LIDODVEXIT_EXIT_EPOCH}
       - LIDODVEXIT_LOG_LEVEL=${LIDO_DV_EXIT_LOG_LEVEL:-info}
       - LIDODVEXIT_VALIDATOR_QUERY_CHUNK_SIZE=${LIDO_DV_EXIT_VALIDATOR_QUERY_CHUNK_SIZE:-5}
     restart: on-failure


### PR DESCRIPTION
This means the containers will fail to start if you don't copy a sample env var and hope for the best, because docker will input empty strings for these values, which will not be compatible with the containers. 