### PR TITLE
Feat: Enable Metrics for Nethermind

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,6 +28,8 @@ services:
       --JsonRpc.EnginePort=8551
       --JsonRpc.Host=0.0.0.0
       --JsonRpc.Port=8545
+      --Metrics.Enabled=true
+      --Metrics.ExposePort=6060
       --Sync.SnapSync=true
       --Sync.AncientBodiesBarrier=4367322
       --Sync.AncientReceiptsBarrier=4367322


### PR DESCRIPTION
### PR Type:

- [x] Feature
- [ ] Bugfix
- [ ] Refactoring
- [ ] Documentation
- [ ] Other

### Related Issue(s):
N/A
### Changes Summary:

This PR introduces the necessary option to enable metrics for Nethermind, which are disabled by default. Enabling this feature is crucial for monitoring and performance analysis.
### Implementation Details:

Added the specified configuration option to enable metrics within Nethermind. (ref: [default option](https://docs.nethermind.io/fundamentals/configuration/#metrics))
Updated docker-compose.override.yml to allow control over the Nethermind Metric port, making the metrics accessible.

### Testing:

Manual testing was conducted to ensure that metrics are properly enabled and accessible via the specified Metric port.
Verified that the new configuration does not interfere with existing functionalities.
