### PR TITLE
Turn off produce block v3

### DIFF
--- a/docker-compose.override.yml.sample
+++ b/docker-compose.override.yml.sample
@@ -22,7 +22,7 @@
     #ports:
       #- 8545:8545 # JSON-RPC
       #- 8551:8551 # AUTH-RPC
-      #- 6060:6060 # Metrics
+      #- 8008:8008 # Metrics
 
   #lighthouse:
     # Disable lighthouse

--- a/lodestar/run.sh
+++ b/lodestar/run.sh
@@ -34,3 +34,4 @@ exec node /usr/app/packages/cli/bin/lodestar validator \
     --builder="$BUILDER_API_ENABLED" \
     --builder.selection="$BUILDER_SELECTION" \
     --distributed
+    --useProduceBlockV3=false

--- a/lodestar/run.sh
+++ b/lodestar/run.sh
@@ -33,5 +33,5 @@ exec node /usr/app/packages/cli/bin/lodestar validator \
     --beaconNodes="$BEACON_NODE_ADDRESS" \
     --builder="$BUILDER_API_ENABLED" \
     --builder.selection="$BUILDER_SELECTION" \
-    --distributed
+    --distributed \
     --useProduceBlockV3=false


### PR DESCRIPTION
Until charon v1 is released, produce block v3 needs to be turned off.