### PR TITLE
docker-compose.yml: parametrize mev-boost image name

### DIFF
--- a/.env.sample.holesky
+++ b/.env.sample.holesky
@@ -84,6 +84,9 @@ LIGHTHOUSE_CHECKPOINT_SYNC_URL=https://checkpoint-sync.holesky.ethpandaops.io/
 # MEV-Boost docker container image version, e.g. `latest` or `1.6`.
 #MEVBOOST_VERSION=
 
+# MEV-Boost docker container image name, e.g. flashbots/mev-boost.
+#MEVBOOST_IMAGE=
+
 # Comma separated list of MEV-Boost relays. You can choose public relays from https://enchanted-direction-844.notion.site/6d369eb33f664487800b0dedfe32171e?v=d255247c822c409f99c498aeb6a4e51d.
 MEVBOOST_RELAYS=https://0xafa4c6985aa049fb79dd37010438cfebeb0f2bd42b115b89dd678dab0670c1de38da0c4e9138c9290a398ecd9a0b3110@boost-relay-holesky.flashbots.net,https://0xb1d229d9c21298a87846c7022ebeef277dfc321fe674fa45312e20b5b6c400bfde9383f801848d7837ed5fc449083a12@relay-holesky.edennetwork.io,https://0xaa58208899c6105603b74396734a6263cc7d947f444f396a90f7b7d3e65d102aec7e5e5291b27e08d02c50a050825c2f@holesky.titanrelay.xyz,https://0x821f2a65afb70e7f2e820a925a9b4c80a159620582c1766b1b09729fec178b11ea22abb3a51f07b288be815a1a2ff516@bloxroute.holesky.blxrbdn.com
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -129,7 +129,7 @@ services:
   #  | | | | | |  __/\ V /_____| |_) | (_) | (_) \__ \ |_
   #  |_| |_| |_|\___| \_/      |_.__/ \___/ \___/|___/\__|
   mev-boost:
-    image: flashbots/mev-boost:${MEVBOOST_VERSION:-1.7}
+    image: ${MEVBOOST_IMAGE:-flashbots/mev-boost}:${MEVBOOST_VERSION:-1.7}
     command: |
       -${NETWORK}
       -loglevel=debug


### PR DESCRIPTION
Add and document `MEVBOOST_IMAGE` environment variable, allowing operators to choose a specific mev-boost docker image.