### PR TITLE
fix(readme): update readme link to Obol docs for frequent errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,4 +40,4 @@ You will need a `.charon/` folder from a completed DKG present to complete the s
 
 # FAQs
 
-Check the Obol docs for frequent [errors and resolutions](https://docs.obol.tech/docs/int/faq/errors).
+Check the Obol docs for frequent [errors and resolutions](https://docs.obol.tech/docs/faq/errors).


### PR DESCRIPTION
The README.md contains a link to the FAQ on the Obol website, which leads to a non-existent resource (i.e., a 404 error).