### PR TITLE
*: bump charon to v1.0.0-rc2

### DIFF
--- a/.env.sample.holesky
+++ b/.env.sample.holesky
@@ -51,7 +51,7 @@ LIGHTHOUSE_CHECKPOINT_SYNC_URL=https://checkpoint-sync.holesky.ethpandaops.io/
 
 ######### Charon Config #########
 
-# Charon docker container image version, e.g. `latest` or `v0.18.0`.
+# Charon docker container image version, e.g. `latest` or `v1.0.0-rc2`.
 # See available tags https://hub.docker.com/r/obolnetwork/charon/tags.
 #CHARON_VERSION=
 

--- a/.env.sample.mainnet
+++ b/.env.sample.mainnet
@@ -45,7 +45,7 @@ LIGHTHOUSE_CHECKPOINT_SYNC_URL=https://mainnet.checkpoint.sigp.io/
 
 ######### Charon Config #########
 
-# Charon docker container image version, e.g. `latest` or `v0.19.0`.
+# Charon docker container image version, e.g. `latest` or `v1.0.0-rc2`.
 # See available tags https://hub.docker.com/r/obolnetwork/charon/tags.
 #CHARON_VERSION=
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -78,7 +78,7 @@ services:
   #  \___|_| |_|\__,_|_|  \___/|_| |_|
 
   charon:
-    image: obolnetwork/charon:${CHARON_VERSION:-v0.19.1}
+    image: obolnetwork/charon:${CHARON_VERSION:-v1.0.0-rc2}
     environment:
       - CHARON_BEACON_NODE_ENDPOINTS=${CHARON_BEACON_NODE_ENDPOINTS:-http://lighthouse:5052}
       - CHARON_LOG_LEVEL=${CHARON_LOG_LEVEL:-debug}

--- a/lodestar/run.sh
+++ b/lodestar/run.sh
@@ -33,5 +33,4 @@ exec node /usr/app/packages/cli/bin/lodestar validator \
     --beaconNodes="$BEACON_NODE_ADDRESS" \
     --builder="$BUILDER_API_ENABLED" \
     --builder.selection="$BUILDER_SELECTION" \
-    --distributed \
-    --useProduceBlockV3=false
+    --distributed

--- a/relay/docker-compose.yml
+++ b/relay/docker-compose.yml
@@ -8,7 +8,7 @@ services:
 #
   relay:
     # Pegged charon version (update this for each release).
-    image: obolnetwork/charon:${CHARON_VERSION:-v0.15.0}
+    image: obolnetwork/charon:${CHARON_VERSION:-v1.0.0-rc2}
     environment:
       CHARON_P2P_TCP_ADDRESS: 0.0.0.0:3610
       CHARON_HTTP_ADDRESS: 0.0.0.0:3640


### PR DESCRIPTION
Bump charon version to v1.0.0-rc2.
Remove the `useProduceBlockV3` flag from Lodestar.