### PR TITLE
Bump to charon `v1.0.0-rc3`

### DIFF
--- a/.env.sample.holesky
+++ b/.env.sample.holesky
@@ -51,7 +51,7 @@ LIGHTHOUSE_CHECKPOINT_SYNC_URL=https://checkpoint-sync.holesky.ethpandaops.io/
 
 ######### Charon Config #########
 
-# Charon docker container image version, e.g. `latest` or `v1.0.0-rc2`.
+# Charon docker container image version, e.g. `latest` or `v1.0.0-rc3`.
 # See available tags https://hub.docker.com/r/obolnetwork/charon/tags.
 #CHARON_VERSION=
 

--- a/.env.sample.mainnet
+++ b/.env.sample.mainnet
@@ -45,7 +45,7 @@ LIGHTHOUSE_CHECKPOINT_SYNC_URL=https://mainnet.checkpoint.sigp.io/
 
 ######### Charon Config #########
 
-# Charon docker container image version, e.g. `latest` or `v1.0.0-rc2`.
+# Charon docker container image version, e.g. `latest` or `v1.0.0-rc3`.
 # See available tags https://hub.docker.com/r/obolnetwork/charon/tags.
 #CHARON_VERSION=
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -78,7 +78,7 @@ services:
   #  \___|_| |_|\__,_|_|  \___/|_| |_|
 
   charon:
-    image: obolnetwork/charon:${CHARON_VERSION:-v1.0.0-rc2}
+    image: obolnetwork/charon:${CHARON_VERSION:-v1.0.0-rc3}
     environment:
       - CHARON_BEACON_NODE_ENDPOINTS=${CHARON_BEACON_NODE_ENDPOINTS:-http://lighthouse:5052}
       - CHARON_LOG_LEVEL=${CHARON_LOG_LEVEL:-debug}

--- a/relay/docker-compose.yml
+++ b/relay/docker-compose.yml
@@ -8,7 +8,7 @@ services:
 #
   relay:
     # Pegged charon version (update this for each release).
-    image: obolnetwork/charon:${CHARON_VERSION:-v1.0.0-rc2}
+    image: obolnetwork/charon:${CHARON_VERSION:-v1.0.0-rc3}
     environment:
       CHARON_P2P_TCP_ADDRESS: 0.0.0.0:3610
       CHARON_HTTP_ADDRESS: 0.0.0.0:3640


### PR DESCRIPTION
This is for holesky wave users first. Instructions will be given to mainnet operators on when to upgrade separately. 