### PR TITLE
kalo/builderonly-to-builderalways

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -116,7 +116,7 @@ services:
       BEACON_NODE_ADDRESS: http://charon:3600
       NETWORK: ${NETWORK}
       BUILDER_API_ENABLED: ${BUILDER_API_ENABLED:-true}
-      BUILDER_SELECTION: ${BUILDER_SELECTION:-builderonly}
+      BUILDER_SELECTION: ${BUILDER_SELECTION:-builderalways}
     volumes:
       - ./lodestar/run.sh:/opt/lodestar/run.sh
       - .charon/validator_keys:/home/charon/validator_keys


### PR DESCRIPTION
Change builder selection flag from builderonly to builderalways. This way blocks created by builder are still prioritised, but in case call to MEV relay fails for whatever reason, local block building is done (instead of failing completely).