### PR TITLE
Bump dv-exit and ensure it restarts

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -213,7 +213,7 @@ services:
   #
 
   lido-dv-exit:
-    image: obolnetwork/lido-dv-exit:${LIDO_DV_EXIT_VERSION:-e8bee1f}
+    image: obolnetwork/lido-dv-exit:${LIDO_DV_EXIT_VERSION:-c4c00c3}
     user: ":"
     networks: [dvnode]
     volumes:
@@ -226,7 +226,7 @@ services:
       - LIDODVEXIT_EXIT_EPOCH=${LIDODVEXIT_EXIT_EPOCH}
       - LIDODVEXIT_LOG_LEVEL=${LIDO_DV_EXIT_LOG_LEVEL:-info}
       - LIDODVEXIT_VALIDATOR_QUERY_CHUNK_SIZE=${LIDO_DV_EXIT_VALIDATOR_QUERY_CHUNK_SIZE:-5}
-    restart: on-failure
+    restart: unless-stopped
 
 networks:
   dvnode:


### PR DESCRIPTION
Lido-DV-Exit sidecar was not updated to charon 1.0.1 dependency.

Also had a restart policy of on-failure, meaning it didn't restart after a shutdown without an explicit up command.
