### PR TITLE
Bump charon to v1.1.0

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,7 +46,7 @@ services:
   #      |___/
 
   lighthouse:
-    image: sigp/lighthouse:${LIGHTHOUSE_VERSION:-v5.2.1}
+    image: sigp/lighthouse:${LIGHTHOUSE_VERSION:-v5.3.0}
     ports:
       - ${LIGHTHOUSE_PORT_P2P:-9000}:9000/tcp # P2P TCP
       - ${LIGHTHOUSE_PORT_P2P:-9000}:9000/udp # P2P UDP
@@ -78,7 +78,7 @@ services:
   #  \___|_| |_|\__,_|_|  \___/|_| |_|
 
   charon:
-    image: obolnetwork/charon:${CHARON_VERSION:-v1.0.1}
+    image: obolnetwork/charon:${CHARON_VERSION:-v1.1.0}
     environment:
       - CHARON_BEACON_NODE_ENDPOINTS=${CHARON_BEACON_NODE_ENDPOINTS:-http://lighthouse:5052}
       - CHARON_LOG_LEVEL=${CHARON_LOG_LEVEL:-debug}
@@ -108,7 +108,7 @@ services:
   # |_|\___/ \__,_|\___||___/\__\__,_|_|
 
   lodestar:
-    image: chainsafe/lodestar:${LODESTAR_VERSION:-v1.20.1}
+    image: chainsafe/lodestar:${LODESTAR_VERSION:-v1.20.2}
     depends_on: [charon]
     entrypoint: /opt/lodestar/run.sh
     networks: [dvnode]


### PR DESCRIPTION
Bump charon version to v1.1.0. Bump also Lighthouse to v5.3.0 and Lodestar to v1.20.2 - versions with which charon v1.1.0 was tested.