### PR TITLE
*: sync up with CDVN

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -226,7 +226,7 @@ services:
       - LIDODVEXIT_EXIT_EPOCH=${LIDODVEXIT_EXIT_EPOCH}
       - LIDODVEXIT_LOG_LEVEL=${LIDO_DV_EXIT_LOG_LEVEL:-info}
       - LIDODVEXIT_VALIDATOR_QUERY_CHUNK_SIZE=${LIDO_DV_EXIT_VALIDATOR_QUERY_CHUNK_SIZE:-5}
-    restart: on-failure
+    restart: unless-stopped
 
 networks:
   dvnode:

--- a/lodestar/run.sh
+++ b/lodestar/run.sh
@@ -1,23 +1,54 @@
 #!/bin/sh
 
-# Remove the existing keystores to avoid keystore locking issues.
-rm -rf /opt/data/cache /opt/data/secrets /opt/data/keystores
+BUILDER_SELECTION="executiononly"
+
+# If the builder API is enabled, override the builder selection to signal Lodestar to prefer proposing blinded blocks, with EL full blocks as a fallback.
+if [ "$BUILDER_API_ENABLED" = "true" ];
+then
+  BUILDER_SELECTION="builderalways"
+fi
+
+DATA_DIR="/opt/data"
+KEYSTORES_DIR="${DATA_DIR}/keystores"
+SECRETS_DIR="${DATA_DIR}/secrets"
+
+mkdir -p "${KEYSTORES_DIR}" "${SECRETS_DIR}"
+
+IMPORTED_COUNT=0
+EXISTING_COUNT=0
 
 for f in /home/charon/validator_keys/keystore-*.json; do
     echo "Importing key ${f}"
 
-    # Import keystore with password.
-    node /usr/app/packages/cli/bin/lodestar validator import \
-        --dataDir="/opt/data" \
-        --network="$NETWORK" \
-        --importKeystores="$f" \
-        --importKeystoresPassword="${f//json/txt}"
+    # Extract pubkey from keystore file
+    PUBKEY="0x$(grep '"pubkey"' "$f" | awk -F'"' '{print $4}')"
+
+    PUBKEY_DIR="${KEYSTORES_DIR}/${PUBKEY}"
+
+    # Skip import if keystore already exists
+    if [ -d "${PUBKEY_DIR}" ]; then
+        EXISTING_COUNT=$((EXISTING_COUNT + 1))
+        continue
+    fi
+
+    mkdir -p "${PUBKEY_DIR}"
+
+    # Copy the keystore file to persisted keys backend
+    install -m 600 "$f" "${PUBKEY_DIR}/voting-keystore.json"
+
+    # Copy the corresponding password file
+    PASSWORD_FILE="${f%.json}.txt"
+    install -m 600 "${PASSWORD_FILE}" "${SECRETS_DIR}/${PUBKEY}"
+
+    IMPORTED_COUNT=$((IMPORTED_COUNT + 1))
 done
 
-echo "Imported all keys"
+echo "Processed all keys imported=${IMPORTED_COUNT}, existing=${EXISTING_COUNT}, total=$(ls /home/charon/validator_keys/keystore-*.json | wc -l)"
 
 exec node /usr/app/packages/cli/bin/lodestar validator \
-    --dataDir="/opt/data" \
+    --dataDir="$DATA_DIR" \
+    --keystoresDir="$KEYSTORES_DIR" \
+    --secretsDir="$SECRETS_DIR" \
     --network="$NETWORK" \
     --metrics=true \
     --metrics.address="0.0.0.0" \
@@ -25,4 +56,5 @@ exec node /usr/app/packages/cli/bin/lodestar validator \
     --beaconNodes="$BEACON_NODE_ADDRESS" \
     --builder="$BUILDER_API_ENABLED" \
     --builder.selection="$BUILDER_SELECTION" \
-    --distributed
+    --distributed \
+    --useProduceBlockV3=true

--- a/lodestar/run.sh
+++ b/lodestar/run.sh
@@ -56,5 +56,4 @@ exec node /usr/app/packages/cli/bin/lodestar validator \
     --beaconNodes="$BEACON_NODE_ADDRESS" \
     --builder="$BUILDER_API_ENABLED" \
     --builder.selection="$BUILDER_SELECTION" \
-    --distributed \
-    --useProduceBlockV3=true
+    --distributed


### PR DESCRIPTION
Some changes imported from CDVN:
 - [make lodestar POSIX compliant](https://github.com/ObolNetwork/charon-distributed-validator-node/pull/277)
 - [switch to `builderalways` on lodestar](https://github.com/ObolNetwork/charon-distributed-validator-node/pull/274)
 - [speed up lodestar key import](https://github.com/ObolNetwork/charon-distributed-validator-node/pull/273)
 - move to `unless-stopped` as restart policy for lido-dv-exit