### PR TITLE
Move logging to second file so its opt-in

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,5 +10,5 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - run: docker-compose up --no-start
-    - run: docker-compose -f docker-compose.yml -f compose-debug.yml up --no-start
+    - run: docker compose up --no-start
+    - run: docker compose -f docker-compose.yml -f compose-debug.yml -f logging.yml up --no-start

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Finally, to run the cluster run one of the following commands.
 # To start the minimum amount of services
 docker compose up -d
 
-# To also start logging containers which will allow the Obol Core team to help identify cluster issues
+# To also start a promtail container which will stream logs to the Obol Core team to help identify cluster issues
 docker compose -f docker-compose.yml -f logging.yml up -d
 ```
 

--- a/README.md
+++ b/README.md
@@ -38,6 +38,16 @@ To configure this repo for a particular network, follow these instructions. If y
 
 You will need a `.charon/` folder from a completed DKG present to complete the setup of this repo. 
 
+Finally, to run the cluster run one of the following commands.
+
+```sh
+# To start the minimum amount of services
+docker compose up -d
+
+# To also start logging containers which will allow the Obol Core team to help identify cluster issues
+docker compose -f docker-compose.yml -f logging.yml up -d
+```
+
 # FAQs
 
 Check the Obol docs for frequent [errors and resolutions](https://docs.obol.tech/docs/faq/errors).

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.8"
-
 # Override any defaults specified by `${FOO:-bar}` in `.env` with `FOO=qux`.
 # ${VARIABLE:-default} evaluates to default if VARIABLE is unset or empty in the environment.
 # ${VARIABLE-default} evaluates to default only if VARIABLE is unset in the environment.
@@ -173,24 +171,7 @@ services:
       - ./data/grafana:/var/lib/grafana
     restart: unless-stopped
 
-  loki:
-    image: grafana/loki:${LOKI_VERSION:-2.8.2}
-    user: ":"
-    networks: [dvnode]
-    command: -config.file=/etc/loki/loki.yml
-    volumes:
-      - ./loki/loki.yml:/etc/loki/loki.yml
-      - ./data/loki:/opt/loki
-    restart: unless-stopped
 
-  promtail:
-    image: grafana/promtail:${PROMTAIL_VERSION:-2.8.2}
-    command: -config.file=/etc/promtail/config.yml
-    volumes:
-      - ./promtail/config.yml:/etc/promtail/config.yml
-      - /var/run/docker.sock:/var/run/docker.sock
-    networks: [dvnode]
-    restart: unless-stopped
 
   #             _ _     _       _                        _           _
   # __   ____ _| (_) __| | __ _| |_ ___  _ __       ___ (_) ___  ___| |_ ___  _ __

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -125,8 +125,8 @@ services:
       - ./data/lodestar:/opt/data
     restart: unless-stopped
 
-  #      _                     _
-  #  _ __ ___   _____   __    | |__   ___   ___  ___| |_
+  #                             _                     _
+  #   _ __ ___   _____   __    | |__   ___   ___  ___| |_
   #  | '_ ` _ \ / _ \ \ / /____| '_ \ / _ \ / _ \/ __| __|
   #  | | | | | |  __/\ V /_____| |_) | (_) | (_) \__ \ |_
   #  |_| |_| |_|\___| \_/      |_.__/ \___/ \___/|___/\__|
@@ -171,7 +171,15 @@ services:
       - ./data/grafana:/var/lib/grafana
     restart: unless-stopped
 
-
+  loki:
+    image: grafana/loki:${LOKI_VERSION:-2.8.2}
+    user: ":"
+    networks: [dvnode]
+    command: -config.file=/etc/loki/loki.yml
+    volumes:
+      - ./loki/loki.yml:/etc/loki/loki.yml
+      - ./data/loki:/opt/loki
+    restart: unless-stopped
 
   #             _ _     _       _                        _           _
   # __   ____ _| (_) __| | __ _| |_ ___  _ __       ___ (_) ___  ___| |_ ___  _ __

--- a/logging.yml
+++ b/logging.yml
@@ -1,13 +1,4 @@
 services:
-  loki:
-    image: grafana/loki:${LOKI_VERSION:-2.8.2}
-    user: ":"
-    networks: [dvnode]
-    command: -config.file=/etc/loki/loki.yml
-    volumes:
-      - ./loki/loki.yml:/etc/loki/loki.yml
-      - ./data/loki:/opt/loki
-    restart: unless-stopped
 
   promtail:
     image: grafana/promtail:${PROMTAIL_VERSION:-2.8.2}
@@ -17,7 +8,6 @@ services:
       - /var/run/docker.sock:/var/run/docker.sock
     networks: [dvnode]
     restart: unless-stopped
-
 
 networks:
   dvnode:

--- a/logging.yml
+++ b/logging.yml
@@ -1,0 +1,23 @@
+services:
+  loki:
+    image: grafana/loki:${LOKI_VERSION:-2.8.2}
+    user: ":"
+    networks: [dvnode]
+    command: -config.file=/etc/loki/loki.yml
+    volumes:
+      - ./loki/loki.yml:/etc/loki/loki.yml
+      - ./data/loki:/opt/loki
+    restart: unless-stopped
+
+  promtail:
+    image: grafana/promtail:${PROMTAIL_VERSION:-2.8.2}
+    command: -config.file=/etc/promtail/config.yml
+    volumes:
+      - ./promtail/config.yml:/etc/promtail/config.yml
+      - /var/run/docker.sock:/var/run/docker.sock
+    networks: [dvnode]
+    restart: unless-stopped
+
+
+networks:
+  dvnode:


### PR DESCRIPTION
## Problem to be solved

- Collecting logs from operators when there is an issue takes a long time and is the most labour intensive part of diagnosing an issue with the cluster
- We want to give operators a choice about what they share with Obol when it comes to their data


## Proposed solution

This PR moves promtail to a second compose file, so operators can opt to run it by changing their `docker compose up -d` command to `docker compose -f docker-compose.yml -f logging.yml up -d`. 