### PR TITLE
Update MEV-Boost relays and bump MEV-Boost version to 1.9rc3

### DIFF
--- a/.env.sample.hoodi
+++ b/.env.sample.hoodi
@@ -107,7 +107,7 @@ CHARON_P2P_RELAYS=https://0.relay.obol.tech,https://1.relay.obol.tech/,https://c
 #MEVBOOST_IMAGE=
 
 # Comma separated list of MEV-Boost relays. You can choose public relays from https://enchanted-direction-844.notion.site/6d369eb33f664487800b0dedfe32171e?v=d255247c822c409f99c498aeb6a4e51d.
-MEVBOOST_RELAYS=https://0xaa58208899c6105603b74396734a6263cc7d947f444f396a90f7b7d3e65d102aec7e5e5291b27e08d02c50a050825c2f@hoodi.titanrelay.xyz
+MEVBOOST_RELAYS=https://0x98f0ef62f00780cf8eb06701a7d22725b9437d4768bb19b363e882ae87129945ec206ec2dc16933f31d983f8225772b6@hoodi.aestus.live,https://0xaa58208899c6105603b74396734a6263cc7d947f444f396a90f7b7d3e65d102aec7e5e5291b27e08d02c50a050825c2f@hoodi.titanrelay.xyz
 
 ##### validator-ejector Config #####
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -140,7 +140,7 @@ services:
   #  | | | | | |  __/\ V /_____| |_) | (_) | (_) \__ \ |_
   #  |_| |_| |_|\___| \_/      |_.__/ \___/ \___/|___/\__|
   mev-boost:
-    image: ${MEVBOOST_IMAGE:-flashbots/mev-boost}:${MEVBOOST_VERSION:-1.9rc2}
+    image: ${MEVBOOST_IMAGE:-flashbots/mev-boost}:${MEVBOOST_VERSION:-1.9rc3}
     command: |
       -${NETWORK}
       -loglevel=debug


### PR DESCRIPTION
# Summary
This pull request updates the MEV-Boost relays and upgrades the MEV-Boost version to 1.9rc3.

# Changes
- Updated the list of MEV-Boost relays to align with the latest Lido approved [list](https://enchanted-direction-844.notion.site/6d369eb33f664487800b0dedfe32171e?v=1bdbf633d0c980ddb2c3000ce3c37311).
- Bumped the MEV-Boost version to 1.9rc3.
