### PR TITLE
Update lighthouse to v7.0.0-beta.5 in docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,7 +46,7 @@ services:
   #      |___/
 
   lighthouse:
-    image: sigp/lighthouse:${LIGHTHOUSE_VERSION:-v7.0.0-beta.4}
+    image: sigp/lighthouse:${LIGHTHOUSE_VERSION:-v7.0.0-beta.5}
     ports:
       - ${LIGHTHOUSE_PORT_P2P:-9000}:9000/tcp # P2P TCP
       - ${LIGHTHOUSE_PORT_P2P:-9000}:9000/udp # P2P UDP


### PR DESCRIPTION
# Description 
This pull request updates the Lighthouse image version to v7.0.0-beta.5 in the docker-compose.yml file. This release addresses a significant consensus bug affecting all Electra networks in Lighthouse versions prior to v7.0.0-beta.5.

# Changes

Updated the Lighthouse image in docker-compose.yml to v7.0.0-beta.5.