### PR TITLE
Paramaterise mev boost timeouts

### DIFF
--- a/.env.sample.holesky
+++ b/.env.sample.holesky
@@ -102,6 +102,9 @@ CHARON_P2P_RELAYS=https://0.relay.obol.tech,https://1.relay.obol.tech/,https://c
 
 # MEV-Boost docker container image version, e.g. `latest` or `1.6`.
 #MEVBOOST_VERSION=
+#MEVBOOST_TIMEOUT_GETHEADER=
+#MEVBOOST_TIMEOUT_GETPAYLOAD=
+#MEVBOOST_TIMEOUT_REGVAL=
 
 # MEV-Boost docker container image name, e.g. flashbots/mev-boost.
 #MEVBOOST_IMAGE=

--- a/.env.sample.hoodi
+++ b/.env.sample.hoodi
@@ -102,6 +102,9 @@ CHARON_P2P_RELAYS=https://0.relay.obol.tech,https://1.relay.obol.tech/,https://c
 
 # MEV-Boost docker container image version, e.g. `latest` or `1.6`.
 #MEVBOOST_VERSION=
+#MEVBOOST_TIMEOUT_GETHEADER=
+#MEVBOOST_TIMEOUT_GETPAYLOAD=
+#MEVBOOST_TIMEOUT_REGVAL=
 
 # MEV-Boost docker container image name, e.g. flashbots/mev-boost.
 #MEVBOOST_IMAGE=

--- a/.env.sample.mainnet
+++ b/.env.sample.mainnet
@@ -96,6 +96,9 @@ CHARON_P2P_RELAYS=https://0.relay.obol.tech,https://1.relay.obol.tech/,https://c
 
 # MEV-Boost docker container image version, e.g. `latest` or `1.6`.
 #MEVBOOST_VERSION=
+#MEVBOOST_TIMEOUT_GETHEADER=
+#MEVBOOST_TIMEOUT_GETPAYLOAD=
+#MEVBOOST_TIMEOUT_REGVAL=
 
 # Comma separated list of MEV-Boost relays.
 # You can choose public mainnet relays from https://enchanted-direction-844.notion.site/6d369eb33f664487800b0dedfe32171e?v=d255247c822c409f99c498aeb6a4e51d.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,7 +46,7 @@ services:
   #      |___/
 
   lighthouse:
-    image: sigp/lighthouse:${LIGHTHOUSE_VERSION:-v7.0.0-beta.4}
+    image: sigp/lighthouse:${LIGHTHOUSE_VERSION:-v7.0.0-beta.5}
     ports:
       - ${LIGHTHOUSE_PORT_P2P:-9000}:9000/tcp # P2P TCP
       - ${LIGHTHOUSE_PORT_P2P:-9000}:9000/udp # P2P UDP
@@ -147,6 +147,9 @@ services:
       -addr=0.0.0.0:18550
       -relay-check
       -relays=${MEVBOOST_RELAYS}
+      -request-timeout-getheader=${MEVBOOST_TIMEOUT_GETHEADER:-950}
+      -request-timeout-getpayload=${MEVBOOST_TIMEOUT_GETPAYLOAD:-4000}
+      -request-timeout-regval=${MEVBOOST_TIMEOUT_REGVAL:-3000}
     labels:
       - "promtail-monitored=${MEV_BOOST_PROMTAIL_MONITORED:-true}"
     networks: [dvnode]


### PR DESCRIPTION
## Problem to be solved

950ms is a long time to waste on a hanging request, but modifying the value requires changes to docker compose. 


## Proposed solution

This PR adds .env vars that can be used to override the default timeouts on mev-boost, without causing future git conflicts. 