### PR TITLE
Update charon to v1.3.3

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -82,7 +82,7 @@ services:
   #  \___|_| |_|\__,_|_|  \___/|_| |_|
 
   charon:
-    image: obolnetwork/charon:${CHARON_VERSION:-v1.3.2}
+    image: obolnetwork/charon:${CHARON_VERSION:-v1.3.3}
     environment:
       - CHARON_BEACON_NODE_ENDPOINTS=${CHARON_BEACON_NODE_ENDPOINTS:-http://lighthouse:5052}
       - CHARON_BEACON_NODE_HEADERS=${CHARON_BEACON_NODE_HEADERS:-}


### PR DESCRIPTION
v1.3.3 handles older versions of charon (v1.3.1 and below) more gracefully than v1.3.2 does. This patch allows clusters to upgrade less synchronously than they would otherwise need to. 