### PR TITLE
reduce get header timeout

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -156,7 +156,7 @@ services:
       -addr=0.0.0.0:18550
       -relay-check
       -relays=${MEVBOOST_RELAYS}
-      -request-timeout-getheader=${MEVBOOST_TIMEOUT_GETHEADER:-950}
+      -request-timeout-getheader=${MEVBOOST_TIMEOUT_GETHEADER:-600}
       -request-timeout-getpayload=${MEVBOOST_TIMEOUT_GETPAYLOAD:-4000}
       -request-timeout-regval=${MEVBOOST_TIMEOUT_REGVAL:-3000}
     labels:


### PR DESCRIPTION
After mev-boost introduced `x-timeout-ms` in `1.10a3`, we can safely reduce the timeout for get header.