### PR TITLE
fix: pin GitHub Actions to SHA for supply chain security

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -10,12 +10,12 @@ jobs:
       contents: write
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
 
       - name: Bump version & push tag
-        uses: anothrNick/github-tag-action@v1
+        uses: anothrNick/github-tag-action@4ed44965e0db8dab2b466a16da04aec3cc312fd8 # v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAG_PREFIX: v

--- a/.github/workflows/label-issues.yml
+++ b/.github/workflows/label-issues.yml
@@ -10,7 +10,7 @@ jobs:
     permissions:
       issues: write
     steps:
-      - uses: actions/github-script@v8
+      - uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         with:
           script: |
             github.rest.issues.addLabels({

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,5 +9,5 @@ jobs:
     # Ensures default fresh checkout can create containers.
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - run: docker compose up --no-start


### PR DESCRIPTION
## Summary
- Pin all GitHub Action references to their commit SHA
- Prevents supply chain attacks via tag hijacking
- Same versions, just pinned by SHA instead of mutable tag

## Actions pinned
- `actions/checkout@v6` -> `actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6`
- `anothrNick/github-tag-action@v1` -> `anothrNick/github-tag-action@4ed44965e0db8dab2b466a16da04aec3cc312fd8 # v1`
- `actions/github-script@v8` -> `actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8`