### PR TITLE
feat: add 2+3.relay.obol.dev to charon p2p relays (keep partners)

### DIFF
--- a/.env.sample.hoodi
+++ b/.env.sample.hoodi
@@ -152,7 +152,7 @@ MEV_RELAYS=https://0x98f0ef62f00780cf8eb06701a7d22725b9437d4768bb19b363e882ae871
 #CHARON_VERSION=
 
 # Define custom relays. One or more ENRs or an http URL that return an ENR. Use a comma separated list excluding spaces.
-CHARON_P2P_RELAYS=https://0.relay.obol.tech,https://1.relay.obol.tech/,https://2.relay.obol.dev/,https://3.relay.obol.dev/
+CHARON_P2P_RELAYS=https://0.relay.obol.tech,https://1.relay.obol.tech/,https://2.relay.obol.dev/,https://3.relay.obol.dev/,https://charon-relay.dsrvlabs.dev/,https://relay-2.prod-relay.721.land/
 
 # Connect to one or more external beacon nodes. Use a comma separated list excluding spaces.
 CHARON_BEACON_NODE_ENDPOINTS=http://${CL}:5052

--- a/.env.sample.hoodi
+++ b/.env.sample.hoodi
@@ -152,7 +152,7 @@ MEV_RELAYS=https://0x98f0ef62f00780cf8eb06701a7d22725b9437d4768bb19b363e882ae871
 #CHARON_VERSION=
 
 # Define custom relays. One or more ENRs or an http URL that return an ENR. Use a comma separated list excluding spaces.
-CHARON_P2P_RELAYS=https://0.relay.obol.tech,https://1.relay.obol.tech/,https://charon-relay.dsrvlabs.dev/,https://relay-2.prod-relay.721.land/
+CHARON_P2P_RELAYS=https://0.relay.obol.tech,https://1.relay.obol.tech/,https://2.relay.obol.dev/,https://3.relay.obol.dev/
 
 # Connect to one or more external beacon nodes. Use a comma separated list excluding spaces.
 CHARON_BEACON_NODE_ENDPOINTS=http://${CL}:5052

--- a/.env.sample.mainnet
+++ b/.env.sample.mainnet
@@ -152,7 +152,7 @@ MEV_RELAYS=https://0xa15b52576bcbf1072f4a011c0f99f9fb6c66f3e1ff321f11f461d15e31b
 #CHARON_VERSION=
 
 # Define custom relays. One or more ENRs or an http URL that return an ENR. Use a comma separated list excluding spaces.
-CHARON_P2P_RELAYS=https://0.relay.obol.tech,https://1.relay.obol.tech/,https://charon-relay.dsrvlabs.dev/,https://relay-2.prod-relay.721.land/
+CHARON_P2P_RELAYS=https://0.relay.obol.tech,https://1.relay.obol.tech/,https://2.relay.obol.dev/,https://3.relay.obol.dev/
 
 # Connect to one or more external beacon nodes. Use a comma separated list excluding spaces.
 CHARON_BEACON_NODE_ENDPOINTS=http://${CL}:5052

--- a/.env.sample.mainnet
+++ b/.env.sample.mainnet
@@ -152,7 +152,7 @@ MEV_RELAYS=https://0xa15b52576bcbf1072f4a011c0f99f9fb6c66f3e1ff321f11f461d15e31b
 #CHARON_VERSION=
 
 # Define custom relays. One or more ENRs or an http URL that return an ENR. Use a comma separated list excluding spaces.
-CHARON_P2P_RELAYS=https://0.relay.obol.tech,https://1.relay.obol.tech/,https://2.relay.obol.dev/,https://3.relay.obol.dev/
+CHARON_P2P_RELAYS=https://0.relay.obol.tech,https://1.relay.obol.tech/,https://2.relay.obol.dev/,https://3.relay.obol.dev/,https://charon-relay.dsrvlabs.dev/,https://relay-2.prod-relay.721.land/
 
 # Connect to one or more external beacon nodes. Use a comma separated list excluding spaces.
 CHARON_BEACON_NODE_ENDPOINTS=http://${CL}:5052

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -95,7 +95,7 @@ services:
       - CHARON_FALLBACK_BEACON_NODE_ENDPOINTS=${CHARON_FALLBACK_BEACON_NODE_ENDPOINTS:-}
       - CHARON_LOG_LEVEL=${CHARON_LOG_LEVEL:-debug}
       - CHARON_LOG_FORMAT=${CHARON_LOG_FORMAT:-console}
-      - CHARON_P2P_RELAYS=${CHARON_P2P_RELAYS:-https://0.relay.obol.tech,https://1.relay.obol.tech/}
+      - CHARON_P2P_RELAYS=${CHARON_P2P_RELAYS:-https://0.relay.obol.tech,https://1.relay.obol.tech/,https://2.relay.obol.dev/,https://3.relay.obol.dev/}
       - CHARON_P2P_EXTERNAL_HOSTNAME=${CHARON_P2P_EXTERNAL_HOSTNAME:-} # Empty default required to avoid warnings.
       - CHARON_P2P_TCP_ADDRESS=0.0.0.0:${CHARON_PORT_P2P_TCP:-3610}
       - CHARON_VALIDATOR_API_ADDRESS=0.0.0.0:3600


### PR DESCRIPTION
## Summary

Add the two new Obol-operated charon P2P relays (`2.relay.obol.dev`, `3.relay.obol.dev`) that have already been deployed and are live in the nodeopco fleet config (`obol-infrastructure/nodeopco/ansible/playbooks/group_vars/all.yml`). LCDVN was missing them.

Partner relays (`charon-relay.dsrvlabs.dev`, `relay-2.prod-relay.721.land`) are preserved in `.env.sample.{mainnet,hoodi}` — they keep providing peer-discovery diversity for Lido Simple DVT operators.

## Changes

- `docker-compose.yml` (line 98) — `CHARON_P2P_RELAYS` default now lists all 4 Obol relays:
  - `0.relay.obol.tech`
  - `1.relay.obol.tech`
  - `2.relay.obol.dev` (new)
  - `3.relay.obol.dev` (new)
- `.env.sample.mainnet` + `.env.sample.hoodi` (line 155) — same 4 Obol relays + the 2 partner relays kept (dsrvlabs.dev + 721.land):
  - `0.relay.obol.tech, 1.relay.obol.tech, 2.relay.obol.dev, 3.relay.obol.dev, charon-relay.dsrvlabs.dev, relay-2.prod-relay.721.land`

## Test plan

- [ ] `docker compose config | grep CHARON_P2P_RELAYS` shows all 4 obol relays
- [ ] Fresh `.env` from `.env.sample.mainnet` has the 4 obol + 2 partner relays
- [ ] Restart charon container, confirm peer discovery picks up new relays in logs