### PR TITLE
Gitignore rendered alloy config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,6 @@ teku/validator/
 teku/logs/
 commit-boost/config.toml
 prometheus/prometheus.yml
+
+# Rendered at alloy container start from config.alloy.example; may contain credentials.
+alloy/config.alloy


### PR DESCRIPTION
`alloy/run.sh` renders `alloy/config.alloy` from the example at every container start, embedding `CHARON_LOKI_ADDRESSES` which may contain credentials. Ignore it like the equivalent rendered `prometheus/prometheus.yml` already is, so it cannot be accidentally committed.